### PR TITLE
Upgraded Spring cloud version to 2025.0.0

### DIFF
--- a/05.kubernetes/currency-conversion-service/pom.xml
+++ b/05.kubernetes/currency-conversion-service/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<java.version>21</java.version>
-		<spring-cloud.version>2024.0.1</spring-cloud.version>
+		<spring-cloud.version>2025.0.0</spring-cloud.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Upgraded the Spring cloud version from 2024.0.1 to 2025.0.0 which was required for compatibility with Spring Boot 3.5.0